### PR TITLE
Add test for multiple directions

### DIFF
--- a/test/Data/GeographySpec.hs
+++ b/test/Data/GeographySpec.hs
@@ -106,3 +106,8 @@ spec = do
        getDirection (Coords 2 2) (Coords 3 2) `shouldBe` Just East
      it "returns Nothing if points are the same" $
        getDirection (Coords 2 2) (Coords 2 2) `shouldBe` Nothing
+     it "returns Nothing if points are in multiple directions" $ do
+        getDirection (Coords 2 2) (Coords 1 1) `shouldBe` Nothing
+        getDirection (Coords 2 2) (Coords 1 3) `shouldBe` Nothing
+        getDirection (Coords 2 2) (Coords 3 1) `shouldBe` Nothing
+        getDirection (Coords 2 2) (Coords 3 3) `shouldBe` Nothing


### PR DESCRIPTION
This PR proposes to include a test for the `getDirection` function, which checks, whether it returns `Nothing` if multiple directions should be returned (to prevent ambiguity).